### PR TITLE
New express-openapi-coercion version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ and validation.
 * Performant.
 * Supports custom `format` validators.
   * See [args.customFormats](#argscustomformats)
+* Supports `collectionFormat` for `formData` `array` parameters.
 * Extensively tested.
 * Small footprint.
 * Currently supports openapi 2.0 (f.k.a. swagger 2.0) documents.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "supertest": "^1.1.0"
   },
   "dependencies": {
-    "express-openapi-coercion": "^0.3.3",
+    "express-openapi-coercion": "^0.4.0",
     "express-openapi-defaults": "^0.4.2",
     "express-openapi-response-validation": "^0.2.0",
     "express-openapi-validation": "^0.6.1",


### PR DESCRIPTION
express-openapi-coercion now supports `formData` and `collectionFormat`