### PR TITLE
Fix method doc loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,9 +288,9 @@ function getAdditionalMiddleware() {
 }
 
 function getMethodDoc(methodHandler) {
-  return Array.isArray(methodHandler) ?
-    methodHandler.slice(-1)[0].apiDoc || methodHandler.apiDoc :
-    methodHandler.apiDoc;
+  return methodHandler.apiDoc || (Array.isArray(methodHandler) ?
+    methodHandler.slice(-1)[0].apiDoc :
+    null);
 }
 
 function sortApiDocTags(apiDoc) {

--- a/index.js
+++ b/index.js
@@ -102,9 +102,7 @@ function initialize(args) {
     Object.keys(pathModule).filter(byMethods).forEach(function(methodName) {
       // methodHandler may be an array or a function.
       var methodHandler = pathModule[methodName];
-      var methodDoc = Array.isArray(methodHandler) ?
-          methodHandler.slice(-1)[0].apiDoc :
-          methodHandler.apiDoc;
+      var methodDoc = getMethodDoc(methodHandler);
       var middleware = [].concat(getAdditionalMiddleware(originalApiDoc, originalPathItem,
             pathModule, methodDoc), methodHandler);
       (methodDoc && methodDoc.tags || []).forEach(addOperationTagToApiDoc.bind(null, apiDoc));
@@ -287,6 +285,12 @@ function getAdditionalMiddleware() {
       return doc[ADDITIONAL_MIDDLEWARE_PROPERTY];
     }
   }
+}
+
+function getMethodDoc(methodHandler) {
+  return Array.isArray(methodHandler) ?
+    methodHandler.slice(-1)[0].apiDoc || methodHandler.apiDoc :
+    methodHandler.apiDoc;
 }
 
 function sortApiDocTags(apiDoc) {

--- a/test/sample-projects.js
+++ b/test/sample-projects.js
@@ -166,6 +166,17 @@ describe(require('../package.json').name + 'sample-projects', function() {
     });
   });
 
+  describe('with-apiDoc-as-array-method-handler-property', function() {
+    var app = require('./sample-projects/with-apiDoc-as-array-method-handler-property/app.js');
+    var expectedApiDoc = require('./fixtures/basic-usage-api-doc-after-initialization.json');
+
+    it('should expose <apiDoc>.basePath/api-docs', function(done) {
+      request(app)
+        .get('/v3/api-docs')
+        .expect(200, expectedApiDoc, done);
+    });
+  });
+
   describe('configuring middleware', function() {
     var coercionMissingBody = {
       errors: [

--- a/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-doc.js
+++ b/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-doc.js
@@ -1,0 +1,44 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {
+    Error: {
+      additionalProperties: true
+    },
+    User: {
+      properties: {
+        name: {
+          type: 'string'
+        },
+        friends: {
+          type: 'array',
+          items: {
+            $ref: '#/definitions/User'
+          }
+        }
+      },
+      required: ['name']
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {},
+
+  // tags is optional, and is generated / sorted by the tags defined in your path
+  // docs.  This API also defines 2 tags in operations: "creating" and "fooey".
+  tags: [
+    // {name: 'creating'} will be inserted by ./api-routes/users.js
+    // {name: 'fooey'} will be inserted by ./api-routes/users/{id}.js
+    {name: 'users'}
+  ]
+};

--- a/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-routes/users.js
+++ b/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-routes/users.js
@@ -1,0 +1,48 @@
+// Showing that you don't need to have apiDoc defined on methodHandlers.
+module.exports = {
+  del: function(req, res, next) {
+    // Showing how to validate responses
+    var validationError = res.validateResponse(204, null);
+
+    if (validationError) {
+      return next(validationError);
+    }
+
+    res.status(204).send('').end();
+  },
+  get: [function(req, res, next) {
+    res.status(200).json([{name: 'fred'}]);
+  }],
+
+  post: function(req, res, next) {
+    res.status(500).json({});
+  }
+};
+
+module.exports.del.apiDoc = {
+  description: 'Delete users.',
+  operationId: 'deleteUsers',
+  tags: ['users'],
+  parameters: [],
+  responses: {
+    204: {
+      description: 'Users were successfully deleted.'
+      // 204 should not return a body so not defining a schema.  This adds an implicit
+      // schema of {"type": "null"}.
+    }
+  }
+};
+
+// showing that if parameters are empty, express-openapi adds no input middleware.
+// response middleware is always added.
+module.exports.post.apiDoc = {
+  description: 'Create a new user.',
+  operationId: 'createUser',
+  tags: ['users', 'creating'],
+  parameters: [],
+  responses: {
+    default: {
+      $ref: '#/definitions/Error'
+    }
+  }
+};

--- a/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-routes/users/{id}.js
+++ b/test/sample-projects/with-apiDoc-as-array-method-handler-property/api-routes/users/{id}.js
@@ -1,0 +1,93 @@
+module.exports = {
+  // parameters for all operations in this path
+  parameters: [
+    {
+      name: 'id',
+      in: 'path',
+      type: 'string',
+      required: true,
+      description: 'Fred\'s age.'
+    }
+  ],
+  // method handlers may just be the method handler...
+  get: get,
+  // or they may also be an array of middleware + the method handler.  This allows
+  // for flexible middleware management.  express-openapi middleware generated from
+  // the <path>.parameters + <methodHandler>.apiDoc.parameters is prepended to this
+  // array.
+  post: [function(req, res, next) {next();}, post]
+};
+
+function post(req, res) {
+  res.status(200).json({id: req.params.id});
+}
+
+// verify that apiDoc is available with middleware
+module.exports.post.apiDoc = {
+  description: 'Create a user.',
+  operationId: 'createUser',
+  tags: ['users'],
+  parameters: [
+    {
+      name: 'user',
+      in: 'body',
+      schema: {
+        $ref: '#/definitions/User'
+      }
+    }
+  ],
+
+  responses: {
+    default: {
+      $ref: '#/definitions/Error'
+    }
+  }
+};
+
+function get(req, res) {
+  res.status(200).json({
+    id: req.params.id,
+    name: req.query.name,
+    age: req.query.age
+  });
+}
+
+get.apiDoc = {
+  description: 'Retrieve a user.',
+  operationId: 'getUser',
+  tags: ['users', 'fooey'],
+  parameters: [
+    {
+      name: 'name',
+      in: 'query',
+      type: 'string',
+      pattern: '^fred$',
+      description: 'The name of this person.  It may only be "fred".'
+    },
+    // showing that operation parameters override path parameters
+    {
+      name: 'id',
+      in: 'path',
+      type: 'integer',
+      required: true,
+      description: 'Fred\'s age.'
+    },
+    {
+      name: 'age',
+      in: 'query',
+      type: 'integer',
+      description: 'Fred\'s age.',
+      default: 80
+    }
+  ],
+
+  responses: {
+    200: {
+      $ref: '#/definitions/User'
+    },
+
+    default: {
+      $ref: '#/definitions/Error'
+    }
+  }
+};

--- a/test/sample-projects/with-apiDoc-as-array-method-handler-property/app.js
+++ b/test/sample-projects/with-apiDoc-as-array-method-handler-property/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}

--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -266,7 +266,7 @@ declare module "express-openapi" {
         [index: number]: express.RequestHandler;
     }
 
-    export type Operation = OperationFunction | OperationHandlerArray;
+    export type Operation = OperationFunction | OperationHandlerArray | OperationFunction[];
 
     export interface PathModule {
         parameters?: OpenApi.Parameters;


### PR DESCRIPTION
Allow method doc as REDME style when method handler is Array as in README.

Following style is used in README.
```javascript
module.exports.post = [function (res, req, next) { next();}, post];
function post(res, req, next) { res.status(200}.json({message:'ok'});}
module.exports.post.apiDoc = {
  // api doc here
};
```

On the other hand, implementation and test uses this:
```javascript
module.exports.post = [function (res, req, next) { next();}, post];
function post(res, req, next) { res.status(200}.json({message:'ok'});}
post.apiDoc = {
  // api doc here
};
```

This PR allows both style. And for BC, latter style has priority.