### PR TITLE
	partial fix for #17: Support external schema reference. 

### DIFF
--- a/test/initialization.js
+++ b/test/initialization.js
@@ -79,5 +79,20 @@ describe(require('../package.json').name, function() {
 
       expect(initializedApp.apiDoc).to.eql(expectedApiDoc);
     });
+
+    it('should require referenced parameter to exist', function() {
+      expect(function() {
+        require('./sample-projects/with-referenced-parameter-missing/app.js');
+      }).to.throw(/Invalid parameter \$ref or definition not found in apiDoc\.parameters: #\/parameters\/Boo/);
+
+    });
+
+    it('should require referenced response to exist', function() {
+      expect(function() {
+        require('./sample-projects/with-referenced-response-missing/app.js');
+      }).to.throw(/Invalid response \$ref or definition not found in apiDoc.responses: #\/responses\/SuccessResponse/);
+
+    });
+
   });
 });

--- a/test/sample-projects.js
+++ b/test/sample-projects.js
@@ -79,6 +79,47 @@ describe(require('../package.json').name + 'sample-projects', function() {
     });
   });
 
+  describe('with-apiDoc-parameters-and-responses', function() {
+    var app = require('./sample-projects/with-apiDoc-parameters-and-responses/app.js');
+
+    it('should use parameter references', function(done) {
+      request(app)
+        .get('/v3/foo?name=barney')
+        .expect(400, {
+          status: 400,
+          errors:[
+            {
+              path: 'boo',
+              errorCode: 'required.openapi.validation',
+              message: 'instance requires property \"boo\"',
+              location:'query'
+            },
+            {
+              path: 'foo',
+              errorCode: 'required.openapi.validation',
+              message: 'instance requires property \"foo\"',
+              location: 'query'
+            }
+          ]
+        }, done);
+    });
+
+    it('should use response references', function(done) {
+      request(app)
+        .get('/v3/foo?foo=error&boo=success')
+        .expect(500, {
+          errors: [
+            {
+              errorCode: 'enum.openapi.responseValidation',
+              message: 'response is not one of enum values: error'
+            }
+          ],
+          message: 'The response was not valid.',
+          status: 500
+        }, done);
+    });
+  });
+
   describe('with-errorTransformer', function() {
     var app = require('./sample-projects/with-errorTransformer/app.js');
 

--- a/test/sample-projects/with-apiDoc-parameters-and-responses/api-doc.js
+++ b/test/sample-projects/with-apiDoc-parameters-and-responses/api-doc.js
@@ -1,0 +1,55 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  parameters: {
+    Boo: {
+      in: 'query',
+      type: 'string',
+      name: 'boo',
+      required: true
+    },
+    Foo: {
+      in: 'query',
+      type: 'string',
+      name: 'foo',
+      required: true,
+      enum: [
+        'success',
+        'error'
+      ]
+    }
+  },
+
+  responses: {
+    SuccessResponse: {
+      description: 'A successful response.',
+      schema: {
+        type: 'string',
+        enum: ['success']
+      }
+    },
+
+    ErrorResponse: {
+      description: 'An error occurred.',
+      schema: {
+        type: 'string',
+        enum: ['error']
+      }
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-apiDoc-parameters-and-responses/api-routes/foo.js
+++ b/test/sample-projects/with-apiDoc-parameters-and-responses/api-routes/foo.js
@@ -1,0 +1,35 @@
+module.exports = {
+  parameters: [
+    {
+      $ref: '#/parameters/Boo'
+    }
+  ],
+  get: function(req, res, next) {
+    var statusCode = req.query.foo === 'success' ?
+      200 :
+      500;
+    var errors = res.validateResponse(statusCode, req.query.boo);
+    res.status(statusCode).json(errors);
+  },
+  // handling no method doc
+  post: function() {}
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  parameters: [
+    {
+      $ref: '#/parameters/Foo'
+    }
+  ],
+  responses: {
+    200: {
+      $ref: '#/responses/SuccessResponse'
+    },
+    default: {
+      $ref: '#/responses/ErrorResponse'
+    }
+  }
+};

--- a/test/sample-projects/with-apiDoc-parameters-and-responses/app.js
+++ b/test/sample-projects/with-apiDoc-parameters-and-responses/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}

--- a/test/sample-projects/with-referenced-parameter-missing/api-doc.js
+++ b/test/sample-projects/with-referenced-parameter-missing/api-doc.js
@@ -1,0 +1,39 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  parameters: {
+  },
+
+  responses: {
+    SuccessResponse: {
+      description: 'A successful response.',
+      schema: {
+        type: 'string',
+        enum: ['success']
+      }
+    },
+
+    ErrorResponse: {
+      description: 'An error occurred.',
+      schema: {
+        type: 'string',
+        enum: ['error']
+      }
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-referenced-parameter-missing/api-routes/foo.js
+++ b/test/sample-projects/with-referenced-parameter-missing/api-routes/foo.js
@@ -1,0 +1,35 @@
+module.exports = {
+  parameters: [
+    {
+      $ref: '#/parameters/Boo'
+    }
+  ],
+  get: function(req, res, next) {
+    var statusCode = req.query.foo === 'success' ?
+      200 :
+      500;
+    var errors = res.validateResponse(statusCode, req.query.boo);
+    res.status(statusCode).json(errors);
+  },
+  // handling no method doc
+  post: function() {}
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  parameters: [
+    {
+      $ref: '#/parameters/Foo'
+    }
+  ],
+  responses: {
+    200: {
+      $ref: '#/responses/SuccessResponse'
+    },
+    default: {
+      $ref: '#/responses/ErrorResponse'
+    }
+  }
+};

--- a/test/sample-projects/with-referenced-parameter-missing/app.js
+++ b/test/sample-projects/with-referenced-parameter-missing/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}

--- a/test/sample-projects/with-referenced-response-missing/api-doc.js
+++ b/test/sample-projects/with-referenced-response-missing/api-doc.js
@@ -1,0 +1,37 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  parameters: {
+    Boo: {
+      in: 'query',
+      type: 'string',
+      name: 'boo',
+      required: true
+    },
+    Foo: {
+      in: 'query',
+      type: 'string',
+      name: 'foo',
+      required: true,
+      enum: [
+        'success',
+        'error'
+      ]
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-referenced-response-missing/api-routes/foo.js
+++ b/test/sample-projects/with-referenced-response-missing/api-routes/foo.js
@@ -1,0 +1,35 @@
+module.exports = {
+  parameters: [
+    {
+      $ref: '#/parameters/Boo'
+    }
+  ],
+  get: function(req, res, next) {
+    var statusCode = req.query.foo === 'success' ?
+      200 :
+      500;
+    var errors = res.validateResponse(statusCode, req.query.boo);
+    res.status(statusCode).json(errors);
+  },
+  // handling no method doc
+  post: function() {}
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  parameters: [
+    {
+      $ref: '#/parameters/Foo'
+    }
+  ],
+  responses: {
+    200: {
+      $ref: '#/responses/SuccessResponse'
+    },
+    default: {
+      $ref: '#/responses/ErrorResponse'
+    }
+  }
+};

--- a/test/sample-projects/with-referenced-response-missing/app.js
+++ b/test/sample-projects/with-referenced-response-missing/app.js
@@ -1,0 +1,26 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}


### PR DESCRIPTION
* Supporting  in parameters and responses.
* Only supporting local references at this time to avoid async operations.
* Bumping coverage back up.
* Adding a warning message in the console for $ref: #/definitions/... in responses object.