### PR TITLE
Fix typo in comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function initialize(args) {
   fsRoutes(routesDir).forEach(function(result) {
     var pathModule = require(result.path);
     var route = result.route;
-    // express path pargumentarams start with :paramName
+    // express path params start with :paramName
     // openapi path params use {paramName}
     var openapiPath = route;
     // Do not make modifications to this.


### PR DESCRIPTION
Maybe, `gument` is inserted accidentally unless it is a new word such as even google doesn't know.