### PR TITLE
Fix type definition of `Schema Object` for typescript

### DIFF
--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -231,8 +231,8 @@ declare module "express-openapi" {
             discriminator?: string
             readOnly?: boolean
             xml?: XMLObject
-            externalDocs: ExternalDocumentationObject
-            example: any
+            externalDocs?: ExternalDocumentationObject
+            example?: any
         }
 
         export interface XMLObject {


### PR DESCRIPTION
- now externalDocs and example is optional