### PR TITLE
Support express mount app

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,8 +186,16 @@ function initialize(args) {
   }
 
   if (errorMiddleware) {
-    app.use(apiDoc.basePath, errorMiddleware);
+    app.use(basePath, errorMiddleware);
   }
+
+  function setBasePath() {
+    // none-express app may not have mountpath
+    apiDoc.basePath = (app.mountpath||'').replace(/\/$/, '') + basePath;
+  }
+
+  app.on('mount', setBasePath);
+  setBasePath();
 
   var initializedApi = {
     apiDoc: apiDoc

--- a/test/sample-projects.js
+++ b/test/sample-projects.js
@@ -152,6 +152,32 @@ describe(require('../package.json').name + 'sample-projects', function() {
     });
   });
 
+  describe('with-express-mount-after-initialize', function() {
+    var app = require('./sample-projects/with-express-mount-after-initialize/app.js');
+
+    it('should expose apiDoc containing baseUrl with mountpath', function(done) {
+      request(app)
+        .get('/api/v3/api-docs')
+        .expect(function(res) {
+          expect(res.body).to.have.property('basePath', '/api/v3');
+        })
+        .expect(200, done);
+    });
+  });
+
+  describe('with-express-mount-before-initialize', function() {
+    var app = require('./sample-projects/with-express-mount-before-initialize/app.js');
+
+    it('should expose apiDoc containing baseUrl with mountpath', function(done) {
+      request(app)
+        .get('/api/v3/api-docs')
+        .expect(function(res) {
+          expect(res.body).to.have.property('basePath', '/api/v3');
+        })
+        .expect(200, done);
+    });
+  });
+
   describe('with-customFormats', function() {
     var app = require('./sample-projects/with-customFormats/app.js');
 

--- a/test/sample-projects/with-express-mount-after-initialize/api-doc.js
+++ b/test/sample-projects/with-express-mount-after-initialize/api-doc.js
@@ -1,0 +1,18 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-express-mount-after-initialize/api-routes/foo.js
+++ b/test/sample-projects/with-express-mount-after-initialize/api-routes/foo.js
@@ -1,0 +1,19 @@
+module.exports = {
+  get: function(req, res, next) {
+    res.status(200).json('success');
+  }
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  responses: {
+    default: {
+      description: 'Success',
+      schema: {
+        type: 'string'
+      }
+    }
+  }
+};

--- a/test/sample-projects/with-express-mount-after-initialize/app.js
+++ b/test/sample-projects/with-express-mount-after-initialize/app.js
@@ -1,0 +1,30 @@
+var express = require('express');
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+var parentApp = express();
+var app = express();
+parentApp.use(cors());
+parentApp.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+parentApp.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+parentApp.use('/api', app);
+
+module.exports = parentApp;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  parentApp.listen(port);
+}

--- a/test/sample-projects/with-express-mount-before-initialize/api-doc.js
+++ b/test/sample-projects/with-express-mount-before-initialize/api-doc.js
@@ -1,0 +1,18 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-express-mount-before-initialize/api-routes/foo.js
+++ b/test/sample-projects/with-express-mount-before-initialize/api-routes/foo.js
@@ -1,0 +1,19 @@
+module.exports = {
+  get: function(req, res, next) {
+    res.status(200).json('success');
+  }
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  responses: {
+    default: {
+      description: 'Success',
+      schema: {
+        type: 'string'
+      }
+    }
+  }
+};

--- a/test/sample-projects/with-express-mount-before-initialize/app.js
+++ b/test/sample-projects/with-express-mount-before-initialize/app.js
@@ -1,0 +1,29 @@
+var express = require('express');
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+var parentApp = express();
+var app = express();
+parentApp.use(cors());
+parentApp.use(bodyParser.json());
+
+parentApp.use('/api', app);
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+parentApp.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = parentApp;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  parentApp.listen(port);
+}


### PR DESCRIPTION
refs https://github.com/kogosoftwarellc/express-openapi/issues/3#issuecomment-199412051

```js
var parentApp = express();
var app = express();

parentApp.use('/api', app);

openapi.initialize({
  app: app,
  apiDoc: require('./apiDoc.js'), // basePath = '/v1'
  routes: './routes'
});

// you can also mount here
// parentApp.use('/api', app);
```

Then apiDoc.basePath is `/api/v1`.