### PR TITLE
Fix typo in type definition for typescript

### DIFF
--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -249,7 +249,7 @@ declare module "express-openapi" {
         apiDoc: OpenApi.ApiDefinition
         app: express.Application
         routes: string
-        docPath?: string
+        docsPath?: string
         errorMiddleware?: express.ErrorRequestHandler,
         errorTransformer?(openapiError: OpenapiError, jsonschemaError: JsonschemaError): any
         exposeApiDocs?: boolean


### PR DESCRIPTION
docPath -> docsPath