### PR TITLE
Typing: Fix `Request` interface to follow coercion result.

### DIFF
--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -261,7 +261,11 @@ declare module "express-openapi" {
         (req: Request, res: Response, next: NextFunction): any
     }
 
-    export type Request = express.Request;
+    export interface Request extends express.Request {
+        get(name: string): any
+        header(name: string): any
+        headers: { [key: string]: any }
+    }
     export type NextFunction = express.NextFunction;
     export interface Response extends express.Response {
         validateResponse(status: number, resource: any): {status: number, message: string, errors: any}


### PR DESCRIPTION
`request.get()`, `request.header()`, `request.headers[]` may not returns string only.

because:
https://github.com/kogosoftwarellc/express-openapi-coercion/blob/33a4bdbf95b26675e26db8c4b80ad5a3abc9a013/index.js#L41-L80