### PR TITLE
Support middleware builder

### DIFF
--- a/test/initialization.js
+++ b/test/initialization.js
@@ -25,7 +25,8 @@ describe(require('../package.json').name, function() {
         ['args.routes non directory', {app: {}, apiDoc: validDocument, routes: 'asdasdfasdf'}, /express-openapi: args.routes was not a path to a directory/],
         ['args.routes non directory', {app: {}, apiDoc: validDocument, routes: routesDir, docsPath: true}, /express-openapi: args.docsPath must be a string when given/],
         ['args.errorTransformer', {app: {}, apiDoc: validDocument, routes: routesDir, errorTransformer: 'asdf'}, /express-openapi: args.errorTransformer must be a function when given/],
-        ['args.externalSchemas', {app: {}, apiDoc: validDocument, routes: routesDir, externalSchemas: 'asdf'}, /express-openapi: args.externalSchemas must be a object when given/],
+        ['args.externalSchemas', {app: {}, apiDoc: validDocument, routes: routesDir, externalSchemas: 'asdf'}, /express-openapi: args.externalSchemas must be an object when given/],
+        ['args.middlewareBuilder', {app: {}, apiDoc: validDocument, routes: routesDir, middlewareBuilder: 'asdf'}, /express-openapi: args.middlewareBuilder must be a function when given/],
       ].forEach(function(test) {
         var description = test[0];
         var args = test[1];

--- a/test/sample-projects.js
+++ b/test/sample-projects.js
@@ -399,6 +399,34 @@ describe(require('../package.json').name + 'sample-projects', function() {
     });
   });
 
+  describe('with-middleware-builder', function() {
+    var app = require('./sample-projects/with-middleware-builder/app.js');
+
+    it('should call additional middleware before express-openapi middleware', function(done) {
+      request(app)
+        .get('/v3/users')
+        .expect(200, {baz: 'woo'}, done);
+    });
+
+    it('should call additional middleware after express-openapi middleware', function(done) {
+      request(app)
+        .post('/v3/users')
+        .expect(401, done);
+    });
+
+    it('should not call global additional middleware when it disabled in methodDoc', function(done) {
+      request(app)
+        .patch('/v3/users')
+        .expect(200, done);
+    });
+
+    it('should call additional middleware built by method middleware builder', function(done) {
+      request(app)
+        .patch('/v3/users')
+        .expect(200, {message: 'zoo'}, done);
+    });
+  });
+
   describe('configuring middleware', function() {
     var coercionMissingBody = {
       errors: [

--- a/test/sample-projects/with-middleware-builder/api-doc.js
+++ b/test/sample-projects/with-middleware-builder/api-doc.js
@@ -1,0 +1,33 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  basePath: '/v3',
+
+  info: {
+    title: 'invalid express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {
+    Error: {
+      additionalProperties: true
+    },
+    User: {
+      properties: {
+        name: {
+          type: 'string'
+        }
+      },
+      required: ['name']
+    }
+  },
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {},
+
+  tags: [
+    {name: 'users'}
+  ]
+};

--- a/test/sample-projects/with-middleware-builder/api-routes/users.js
+++ b/test/sample-projects/with-middleware-builder/api-routes/users.js
@@ -1,0 +1,61 @@
+// Showing that you don't need to have apiDoc defined on methodHandlers.
+module.exports = {
+  get: [function(req, res, next) {
+    res.status(200).json({baz: req.query.baz});
+  }],
+
+  post: function(req, res, next) {
+    res.status(200).json({message: 'foo'});
+  },
+
+  patch: function(req, res, next) {
+    res.status(200).json({message: req.query.baz});
+  }
+};
+
+
+module.exports.get.apiDoc = {
+  parameters: [
+    {
+      in: "query",
+      name: "baz",
+      type: "string",
+      required: true
+    }
+  ],
+  responses: {
+    default: {
+      description: "a response"
+    }
+  }
+};
+
+module.exports.post.apiDoc = {
+  security: [{
+    'api-key': []
+  }],
+  responses: {
+    default: {
+      description: "a response"
+    }
+  }
+};
+
+module.exports.patch.apiDoc = {
+  security: [{
+    'api-key': []
+  }],
+  responses: {
+    default: {
+      description: "a response"
+    }
+  }
+};
+
+module.exports.patch.disableGlobalMiddlewareBuilder = true;
+module.exports.patch.middlewareBuilder = function(middleware, methodDoc, apiDoc) {
+  middleware.unshift(function(req, res, next) {
+    req.query.baz = 'zoo';
+    next();
+  });
+};

--- a/test/sample-projects/with-middleware-builder/app.js
+++ b/test/sample-projects/with-middleware-builder/app.js
@@ -1,0 +1,38 @@
+var app = require('express')();
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes'),
+  middlewareBuilder: function (middleware, methodDoc, apiDoc) {
+    // Add a middleware before express-openapi middleware.
+    middleware.unshift(function (req, res, next) {
+      req.query.baz = 'woo';
+      next();
+    });
+
+    // Add middleware according to methodDoc or apiDoc
+    if (methodDoc.security && methodDoc.security[0]['api-key']) {
+      // Add a middleware after express-openapi middleware.
+      middleware.push(function (req, res, next) {
+        // e.g. security middleware
+        if (req.header('x-api-key') === 'my-api-key') {
+          return next();
+        }
+        next({status: 401, message: 'unauthorized'});
+      });
+    }
+  }
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;

--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -256,6 +256,7 @@ declare module "express-openapi" {
         validateApiDoc?: boolean
         customFormats?: CustomFormats
         externalSchemas?: {[url:string]: any}
+        middlewareBuilder?: MiddlewareBuilder
     }
 
     export interface RequestHandler {
@@ -274,10 +275,14 @@ declare module "express-openapi" {
 
     export interface OperationFunction extends RequestHandler {
         apiDoc?: OpenApi.OperationObject;
+        disableGlobalMiddlewareBuilder?: boolean;
+        middlewareBuilder?: MiddlewareBuilder;
     }
 
     export interface OperationHandlerArray {
         apiDoc?: OpenApi.OperationObject;
+        disableGlobalMiddlewareBuilder?: boolean;
+        middlewareBuilder?: MiddlewareBuilder;
         [index: number]: OperationFunction;
     }
 
@@ -303,6 +308,10 @@ declare module "express-openapi" {
 
     export interface CustomFormats {
         [index: string]: CustomFormatValidator
+    }
+
+    export interface MiddlewareBuilder {
+        (middleware: express.Handler[], methodDoc: OpenApi.OperationObject, apiDoc: OpenApi.ApiDefinition): void;
     }
 
     // Following 2 interfaces are part of jsonschema package.


### PR DESCRIPTION
Add middleware builder support.
This is useful to add middleware dynamically according to `methodDoc` or `apiDoc` for each operations.
In fact, I implemented this to add security middleware according to [`Security Requirement Object`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-requirement-object). You can see simple example of this in sample application `with-middleware-builder` added in this PR. 