### PR TITLE
Update type definition for typescript to allow openapi extended schema

### DIFF
--- a/typings/express-openapi/express-openapi.d.ts
+++ b/typings/express-openapi/express-openapi.d.ts
@@ -233,6 +233,11 @@ declare module "express-openapi" {
             xml?: XMLObject
             externalDocs?: ExternalDocumentationObject
             example?: any
+            default?: any
+            items?: ItemsObject
+            properties?: {
+                [name: string]: SchemaObject
+            }
         }
 
         export interface XMLObject {


### PR DESCRIPTION
Fix my oversight.