### PR TITLE
Update basePath at request time.

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,7 @@ function initialize(args) {
   if (exposeApiDocs) {
     // Swagger UI support
     app.get(basePath + docsPath, function(req, res) {
+      apiDoc.basePath = req.baseUrl + basePath;
       res.status(200).json(apiDoc);
     });
   }
@@ -219,14 +220,6 @@ function initialize(args) {
   if (errorMiddleware) {
     app.use(basePath, errorMiddleware);
   }
-
-  function setBasePath() {
-    // none-express app may not have mountpath
-    apiDoc.basePath = (app.mountpath||'').replace(/\/$/, '') + basePath;
-  }
-
-  app.on('mount', setBasePath);
-  setBasePath();
 
   var initializedApi = {
     apiDoc: apiDoc

--- a/test/sample-projects.js
+++ b/test/sample-projects.js
@@ -209,6 +209,32 @@ describe(require('../package.json').name + 'sample-projects', function() {
     });
   });
 
+  describe('with-express-mount-deeply-nested', function() {
+    var app = require('./sample-projects/with-express-mount-deeply-nested/app.js');
+
+    it('should expose apiDoc containing baseUrl with mountpath', function(done) {
+      request(app)
+        .get('/grandparent/parent/v3/api-docs')
+        .expect(function(res) {
+          expect(res.body).to.have.property('basePath', '/grandparent/parent/v3');
+        })
+        .expect(200, done);
+    });
+  });
+
+  describe('with-express-mount-on-router', function() {
+    var app = require('./sample-projects/with-express-mount-on-router/app.js');
+
+    it('should expose apiDoc containing baseUrl with mountpath', function(done) {
+      request(app)
+        .get('/api/v3/api-docs')
+        .expect(function(res) {
+          expect(res.body).to.have.property('basePath', '/api/v3');
+        })
+        .expect(200, done);
+    });
+  });
+
   describe('with-external-schema-references', function() {
     var app = require('./sample-projects/with-external-schema-references/app.js');
     var expectedApiDoc = require('./fixtures/with-external-schema-references-api-doc-after-initialization.json');

--- a/test/sample-projects/with-express-mount-deeply-nested/api-doc.js
+++ b/test/sample-projects/with-express-mount-deeply-nested/api-doc.js
@@ -1,0 +1,18 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-express-mount-deeply-nested/api-routes/foo.js
+++ b/test/sample-projects/with-express-mount-deeply-nested/api-routes/foo.js
@@ -1,0 +1,19 @@
+module.exports = {
+  get: function(req, res, next) {
+    res.status(200).json('success');
+  }
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  responses: {
+    default: {
+      description: 'Success',
+      schema: {
+        type: 'string'
+      }
+    }
+  }
+};

--- a/test/sample-projects/with-express-mount-deeply-nested/app.js
+++ b/test/sample-projects/with-express-mount-deeply-nested/app.js
@@ -1,0 +1,33 @@
+var express = require('express');
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+var grandparentApp = express();
+var parentApp = express();
+var app = express();
+grandparentApp.use(cors());
+grandparentApp.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+parentApp.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+
+parentApp.use('/parent', app);
+grandparentApp.use('/grandparent', parentApp);
+
+module.exports = grandparentApp;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  parentApp.listen(port);
+}

--- a/test/sample-projects/with-express-mount-on-router/api-doc.js
+++ b/test/sample-projects/with-express-mount-on-router/api-doc.js
@@ -1,0 +1,18 @@
+// args.apiDoc needs to be a js object.  This file could be a json file, but we can't add
+// comments in json files.
+module.exports = {
+  swagger: '2.0',
+
+  // all routes will now have /v3 prefixed.
+  basePath: '/v3',
+
+  info: {
+    title: 'express-openapi sample project',
+    version: '3.0.0'
+  },
+
+  definitions: {},
+
+  // paths are derived from args.routes.  These are filled in by fs-routes.
+  paths: {}
+};

--- a/test/sample-projects/with-express-mount-on-router/api-routes/foo.js
+++ b/test/sample-projects/with-express-mount-on-router/api-routes/foo.js
@@ -1,0 +1,19 @@
+module.exports = {
+  get: function(req, res, next) {
+    res.status(200).json('success');
+  }
+};
+
+module.exports.get.apiDoc = {
+  description: 'Get foo.',
+  operationId: 'getFoo',
+  tags: ['foo'],
+  responses: {
+    default: {
+      description: 'Success',
+      schema: {
+        type: 'string'
+      }
+    }
+  }
+};

--- a/test/sample-projects/with-express-mount-on-router/app.js
+++ b/test/sample-projects/with-express-mount-on-router/app.js
@@ -1,0 +1,30 @@
+var express = require('express');
+var bodyParser = require('body-parser');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+var openapi = require('../../../');
+var path = require('path');
+var cors = require('cors');
+
+var parentApp = express.Router();
+var app = express();
+parentApp.use(cors());
+parentApp.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: require('./api-doc.js'),
+  app: app,
+  routes: path.resolve(__dirname, 'api-routes')
+});
+
+parentApp.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+parentApp.use('/api', app);
+
+module.exports = parentApp;
+
+var port = parseInt(process.argv[2]);
+if (port) {
+  parentApp.listen(port);
+}


### PR DESCRIPTION
Handle nested apps (see issue #40) by updating the basePath when the apiDoc is requested.