### PR TITLE
Bump express-openapi-validation version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "express-openapi-defaults": "^0.4.2",
     "express-openapi-response-validation": "^0.3.0",
     "express-openapi-security": "^0.1.0",
-    "express-openapi-validation": "^0.7.0",
+    "express-openapi-validation": "^0.8.0",
     "fs-routes": "^1.0.0",
     "glob": "*",
     "is-dir": "^1.0.0",


### PR DESCRIPTION
Hi!

Bumping the version for express-openapi-validation: See https://github.com/kogosoftwarellc/express-openapi-validation/pull/4

Thanks!