### PR TITLE
Allow the case insensitive middleware to be added

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,7 @@ export declare module OpenApi {
         'in': string
         description?: string
         required?: boolean
+        [index: string]: any
     }
 
     export interface InBodyParameterObject extends ParameterObject {


### PR DESCRIPTION
I'm not 100% about this, but I get an error when using the middleware in typescript and adding this line removes the error.