### PR TITLE
Static routes before dynamic routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -377,7 +377,13 @@ function byProperty(property, value) {
 }
 
 function byRoute(a, b) {
+  if(isDynamicRoute(a.route) && !isDynamicRoute(b.route)) return 1;
+  if(!isDynamicRoute(a.route) && isDynamicRoute(b.route)) return -1;
   return a.route.localeCompare(b.route);
+}
+
+function isDynamicRoute(route) {
+  return route.indexOf("{")>0;
 }
 
 function byString(el) {


### PR DESCRIPTION
I have following routes:

pathx/{id}
pathx/latest

And it seems that the dynamic pathx/{id} currently takes precedence, over the static pathx/latest, which might not be desired?