### PR TITLE
Lookup operation spec from main apiDoc when none is specified on the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This getting started guide will use the most fundamental concepts of OpenAPI and
     export default apiDoc;
     ```
 
-    You may be wondering why `paths` is an empty object literal.  We'll get to that in a second.
+    You may be wondering why `paths` can be an empty object literal.  We'll get to that in a second.
 
     This is all that is required for our API's main apiDoc.  To see the full list of values
     and options for the main apiDoc you can view [The Schema](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schema).
@@ -154,8 +154,8 @@ This getting started guide will use the most fundamental concepts of OpenAPI and
 
 1. Create path handlers.
 
-    Our `paths` object was empty in the main apiDoc because `express-openapi` generates
-    it for us based on the location of our path handlers.  For this example we'll place
+    Our `paths` object was empty in the main apiDoc because `express-openapi` allows to
+    generate it for us based on the location of our path handlers.  For this example we'll place
     our path handlers under `api-v1/paths/`.
 
     Let's create a `worlds` path:
@@ -349,8 +349,9 @@ api.  An initialized api contains the following properties:
 |----|--------|-----------|
 |Object or String|Y|This is an OpenAPI (swagger 2.0) compliant document.  See the [OpenAPI-Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) for more details.|
 
-`args.apiDoc.paths` should be an empty object.  `express-openapi` will populate this
-for you.  This prevents you from defining your paths in 2 places.
+`args.apiDoc.paths` can be an empty object. In that case `express-openapi` will populate this
+for you based on your operation level apiDocs.
+But it is also possible to have just [one central apiDoc](test/sample-projects/basic-usage-with-central-apiDoc).
 
 `args.apiDoc.basePath` will add a prefix to all paths added by `express-openapi`.
 

--- a/README.md
+++ b/README.md
@@ -154,9 +154,9 @@ This getting started guide will use the most fundamental concepts of OpenAPI and
 
 1. Create path handlers.
 
-    Our `paths` object was empty in the main apiDoc because `express-openapi` allows to
-    generate it for us based on the location of our path handlers.  For this example we'll place
-    our path handlers under `api-v1/paths/`.
+    Our `paths` object was empty in the main apiDoc because `express-openapi` will generate it for us
+    based on the location of our path handlers.
+    For this example we'll place our path handlers under `api-v1/paths/`.
 
     Let's create a `worlds` path:
 
@@ -351,7 +351,7 @@ api.  An initialized api contains the following properties:
 
 `args.apiDoc.paths` can be an empty object. In that case `express-openapi` will populate this
 for you based on your operation level apiDocs.
-But it is also possible to have just [one central apiDoc](test/sample-projects/basic-usage-with-central-apiDoc).
+It is also possible to have just [one central apiDoc](test/sample-projects/basic-usage-with-central-apiDoc).
 
 `args.apiDoc.basePath` will add a prefix to all paths added by `express-openapi`.
 

--- a/index.js
+++ b/index.js
@@ -177,9 +177,13 @@ function initialize(args) {
     // Do not make modifications to this.
     var originalPathItem = originalApiDoc.paths[openapiPath] || {};
     var pathItem = apiDoc.paths[openapiPath] || {};
-    var pathParameters = Array.isArray(pathModule.parameters) ?
-        [].concat(pathModule.parameters) :
-        [];
+    var pathParameters = pathItem.parameters || [];
+
+    // push all parameters defined in the path module to the path parameter list
+    if (Array.isArray(pathModule.parameters)) {
+      Array.prototype.push.apply(pathParameters, pathModule.parameters);
+    }
+
     pathItem.parameters = pathParameters;
     apiDoc.paths[openapiPath] = pathItem;
 

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function initialize(args) {
 
     // push all parameters defined in the path module to the path parameter list
     if (Array.isArray(pathModule.parameters)) {
-      Array.prototype.push.apply(pathParameters, pathModule.parameters);
+      [].push.apply(pathParameters, pathModule.parameters);
     }
 
     pathItem.parameters = pathParameters;

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function initialize(args) {
     Object.keys(pathModule).filter(byMethods).forEach(function(methodName) {
       // operationHandler may be an array or a function.
       var operationHandler = pathModule[methodName];
-      var operationDoc = handleYaml(getMethodDoc(operationHandler));
+      var operationDoc = handleYaml(getMethodDoc(operationHandler)) || pathItem[METHOD_ALIASES[methodName]];
       var middleware = [].concat(getAdditionalMiddleware(originalApiDoc, originalPathItem,
             pathModule, operationDoc));
       (operationDoc && operationDoc.tags || []).forEach(addOperationTagToApiDoc

--- a/test/sample-projects/basic-usage-with-central-apiDoc/README.md
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/README.md
@@ -1,0 +1,7 @@
+# Basic usage with central apiDoc
+
+This test scenario illustrates the usage of `express-openapi` without operation
+level apiDoc definitions. The setup and the test cases are identically to the [basic usage test](../basic-usage).
+
+The only difference is a separation of [controller](api-routes) and openapi-spec logic.
+The whole openapi doc is defined in [api-doc.yml](api-doc.yml).

--- a/test/sample-projects/basic-usage-with-central-apiDoc/api-doc.yml
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/api-doc.yml
@@ -1,0 +1,124 @@
+swagger: '2.0'
+host: test-host
+basePath: /v3
+info:
+  title: express-openapi sample project
+  version: '3.0.0'
+definitions:
+  Error:
+    additionalProperties: true
+  User:
+    properties:
+      name:
+        type: string
+      friends:
+        type: array
+        items:
+          $ref: '#/definitions/User'
+    required:
+      - name
+paths:
+  /users:
+    delete:
+      description: Delete users.
+      operationId: deleteUsers
+      tags:
+        - users
+      parameters: []
+      responses:
+        204:
+          description: Users were successfully deleted.
+          # 204 should not return a body so not defining a schema.  This adds an implicit
+          # schema of {"type": "null"}.
+
+    # showing that if parameters are empty, express-openapi adds no input middleware.
+    # response middleware is always added.
+    post:
+      description: Create a new user.
+      operationId: createUser
+      tags:
+        - users
+        - creating
+      parameters: []
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /users/{id}:
+    # parameters for all operations in this path
+    parameters:
+      - name: id
+        in: path
+        type: string
+        required: true
+        description: Fred's age.
+    get:
+      description: Retrieve a user.
+      operationId: getUser
+      tags:
+        - users
+        - fooey
+      parameters:
+        - name: name
+          in: query
+          type: string
+          pattern: '^fred$'
+          description: The name of this person.  It may only be "fred".
+        # showing that operation parameters override path parameters
+        - name: id
+          in: path
+          type: integer
+          required: true
+          description: Fred's age.
+        - name: age
+          in: query
+          type: integer
+          description: Fred's age.
+          default: 80
+      responses:
+        200:
+          description: Requested user
+          schema:
+            $ref: '#/definitions/User'
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+    post:
+      description: Create a user.
+      operationId: createUser
+      tags:
+        - users
+      parameters:
+        - name: user
+          in: body
+          schema:
+            $ref: '#/definitions/User'
+      responses:
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+  /apiDocs:
+    get:
+      operationId: getApiDoc
+      description: Returns the requested apiDoc
+      parameters:
+        - description: The type of apiDoc to return.
+          in: query
+          name: type
+          type: string
+          enum:
+            - apiDoc
+            - operationDoc
+      responses:
+        200:
+          description: The requested apiDoc.
+          schema:
+            type: object
+        default:
+          description: The requested apiDoc.
+tags:
+  - description: Everything users
+    name: users

--- a/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/apiDocs.js
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/apiDocs.js
@@ -1,0 +1,8 @@
+module.exports = {
+  get: function get(req, res, next) {
+    if (req.query.type === 'apiDoc') {
+      return res.json(req.apiDoc);
+    }
+    return res.json(req.operationDoc);
+  }
+};

--- a/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/users.js
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/users.js
@@ -1,0 +1,20 @@
+// Showing that you don't need to have apiDoc defined on methodHandlers.
+module.exports = {
+  del: function(req, res, next) {
+    // Showing how to validate responses
+    const validationError = res.validateResponse(204, null);
+
+    if (validationError) {
+      return next(validationError);
+    }
+
+    res.status(204).send('').end();
+  },
+  get: [function(req, res, next) {
+    res.status(200).json([{name: 'fred'}]);
+  }],
+
+  post: function(req, res, next) {
+    res.status(500).json({});
+  }
+};

--- a/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/users/{id}.js
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/api-routes/users/{id}.js
@@ -1,0 +1,21 @@
+module.exports = {
+  // method handlers may just be the method handler...
+  get: get,
+  // or they may also be an array of middleware + the method handler.  This allows
+  // for flexible middleware management.  express-openapi middleware generated from
+  // the <path>.parameters + <methodHandler>.apiDoc.parameters is prepended to this
+  // array.
+  post: [function(req, res, next) {next();}, post]
+};
+
+function post(req, res) {
+  res.status(200).json({id: req.params.id});
+}
+
+function get(req, res) {
+  res.status(200).json({
+    id: req.params.id,
+    name: req.query.name,
+    age: req.query.age
+  });
+}

--- a/test/sample-projects/basic-usage-with-central-apiDoc/app.js
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/app.js
@@ -1,0 +1,27 @@
+const app = require('express')();
+const bodyParser = require('body-parser');
+const fs = require('fs');
+// normally you'd just do require('express-openapi'), but this is for test purposes.
+const openapi = require('../../../');
+const path = require('path');
+const cors = require('cors');
+
+app.use(cors());
+app.use(bodyParser.json());
+
+openapi.initialize({
+  apiDoc: fs.readFileSync(path.resolve(__dirname, 'api-doc.yml'), 'utf8'),
+  app: app,
+  paths: path.resolve(__dirname, 'api-routes')
+});
+
+app.use(function(err, req, res, next) {
+  res.status(err.status).json(err);
+});
+
+module.exports = app;
+
+const port = parseInt(process.argv[2]);
+if (port) {
+  app.listen(port);
+}

--- a/test/sample-projects/basic-usage-with-central-apiDoc/spec.js
+++ b/test/sample-projects/basic-usage-with-central-apiDoc/spec.js
@@ -1,0 +1,87 @@
+const app = require('./app');
+const expect = require('chai').expect;
+const expectedApiDoc = require('../../fixtures/basic-usage-api-doc-after-initialization.json');
+const request = require('supertest');
+
+it('should expose <apiDoc>.basePath/api-docs', function(done) {
+  request(app)
+    .get('/v3/api-docs')
+    .set("Host", "test-host")
+    .expect(200, expectedApiDoc, done);
+});
+
+it('should add response validation middleware when parameters are empty', function(done) {
+  request(app)
+    .delete('/v3/users')
+    .expect(204, '', done);
+});
+
+it('should use defaults, coercion, and operation parameter overriding', function(done) {
+  request(app)
+    .get('/v3/users/34?name=fred')
+    .expect(200)
+    .end(function(err, res) {
+      expect(res.body).to.eql({id: 34, name: 'fred', age: 80});
+      done(err);
+    });
+});
+
+it('should validate input', function(done) {
+  request(app)
+    .get('/v3/users/34?name=barney')
+    .expect(400, {errors: [
+      {
+        errorCode: 'pattern.openapi.validation',
+        location: 'query',
+        message: 'instance.name does not match pattern \"^fred$\"',
+        path: 'name'
+      }
+    ], status: 400}, done);
+});
+
+it('should use path parameters', function(done) {
+  request(app)
+    .post('/v3/users/34')
+    .send({name: 'fred'})
+    .expect(200)
+    .end(function(err, res) {
+      expect(res.body).to.eql({id: '34'});
+      done(err);
+    });
+});
+
+it('should add apiDoc to req', function(done) {
+  request(app)
+    .get('/v3/apiDocs?type=apiDoc')
+    .expect(200)
+    .end(function(err, result) {
+      expect(result.res.body).to.eql(expectedApiDoc);
+      done(err);
+    });
+});
+
+it('should add operationDoc to req', function(done) {
+  request(app)
+    .get('/v3/apiDocs?type=operationDoc')
+    .expect(200)
+    .end(function(err, result) {
+      expect(result.res.body.operationId).to.equal('getApiDoc');
+      done(err);
+    });
+});
+
+it('should dereference #/definitions/ for validation', function(done) {
+  var user = {};
+
+  request(app)
+    .post('/v3/users/34?name=barney')
+    .send(user)
+    .expect(400, {errors: [
+      {
+        errorCode: 'required.openapi.validation',
+        location: 'body',
+        message: 'instance requires property "name"',
+        path: 'name'
+      }
+    ], status: 400}, done);
+});


### PR DESCRIPTION
Provide an alternative and flexible way to pass in operation-level api spec.
If the handler does not provide a dedicated `apiDoc`, fallback to the operation-spec defined in the main apiDoc. 

* [x] Add support for passing path/operation-spec via `initialize({ apiDoc })` 
* [x] Adjust readme
* [x] Add test

resolves #87  